### PR TITLE
chore: rm unnecessary step from test ci

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -7,9 +7,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
removed toolchain install step from test ci