### PR TITLE
chore: enable draft release

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -57,6 +57,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: |
             Release ${{ github.ref }}
+          draft: true
       - name: Upload aarch64-apple-darwin
         uses: actions/upload-release-asset@v1.0.2
         env:


### PR DESCRIPTION
enable draft release on ci